### PR TITLE
Fix pwuid version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "async": "0.2.9",
     "isbinaryfile": "2.0.0",
     "path": "0.11.14",
-    "pwuid": "1.0.1",
+    "pwuid": "1.0.2",
     "shopify-api": "0.2.2",
     "through2": "0.6.3",
     "gulp-util": "3.0.2"


### PR DESCRIPTION
I was getting build failed because pwuid apparently doesn't work with node versions 0.12 and above. Even setting node to 0.11 or 0.10 was breaking. This appears to fix the problem.
