### PR TITLE
Removes unused pwuid dependency (fix for issue #2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "async": "0.2.9",
     "isbinaryfile": "2.0.0",
     "path": "0.11.14",
-    "pwuid": "1.0.2",
     "shopify-api": "0.2.2",
     "through2": "0.6.3",
     "gulp-util": "3.0.2"


### PR DESCRIPTION
Hi Mike,

Please accept this PR, in which I remove the package's dependency on `pwuid` in order to enable usage in Win32 environments. I can't take credit for this, in reality. This is in response to issue #2 and @mikedidthis' [comments](https://github.com/mikenorthorp/gulp-shopify-upload/issues/2#issuecomment-96055208) showing how he worked around this issue. I've tested his fix and concur that the plugin continues to function as intended with its removal.

I believe enabling usage on Win32 environments will be a boon to current and prospective users of your otherwise fantastic plugin.

Regards,
Andy Hunt
