### PR TITLE
Enables setting base path, for added flexibility (fix for #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a port of a similar plugin using Grunt called [grunt-shopify](https://gi
 - Lightweight and fast, changes are uploaded instantly
 
 
-## Usage
+## Basic Usage
 
 1. Download whatever theme you are working on from Shopify to a local directory
 2. Create a [private app](http://docs.shopify.com/api/authentication/creating-a-private-app) in Shopify and get the API Key and Password for it.
@@ -48,7 +48,7 @@ gulp.task('default', [
         'shopifywatch'
 ]);
 ```
-4. The basic function call looks like 
+4. The basic function call looks like
 ```
 gulpShopify('API KEY', 'PASSWORD', 'MYSITE.myshopify.com', 'THEME ID')
 ```
@@ -59,17 +59,20 @@ gulpShopify('API KEY', 'PASSWORD', 'MYSITE.myshopify.com', 'THEME ID')
 4. Run `npm install gulp`, `npm install gulp-watch` and `npm install gulp-shopify-upload`
 5. Run `gulp` and edit one of your theme files, it should automatically be uploaded to Shopify
 
+## Advanced Usage
+If your project structure is different (perhaps you use Gulpjs to compile your theme to another directory), you can change the directory from which the plugin picks up files.
+To do so, simply provide an additional options hash to function call, with a `basePath` property.
+
+```
+var options = {
+	"basePath": "some/other-directory/"
+};
+
+// With a theme id
+gulpShopify('API KEY', 'PASSWORD', 'MYSITE.myshopify.com', 'THEME ID', options)
+
+// Without a theme id
+gulpShopify('API KEY', 'PASSWORD', 'MYSITE.myshopify.com', null, options)
+```
 
 *Created by [Able Sense Media](http://ablesense.com) - 2015*
-
-
-
-
-
-
-
-
-
-
-
-

--- a/index.js
+++ b/index.js
@@ -70,6 +70,16 @@ shopify._getBasePath = function(filebase) {
 };
 
 /**
+ * Sets the base path
+ *
+ * @param {string} basePath
+ * @return {void}
+ */
+shopify._setBasePath = function(basePath) {
+  shopify._basePath = basePath;
+};
+
+/**
 * Make a path relative to base path.
 *
 * @param {string} filepath
@@ -81,6 +91,22 @@ shopify._makePathRelative = function(filepath, base) {
   filepath = path.relative(basePath, filepath);
 
   return filepath.replace(/\\/g, '/');
+};
+
+/**
+ * Applies options to plugin
+ *
+ * @param {object} options
+ * @return {void}
+ */
+shopify._setOptions = function(options) {
+  if(!options){
+    return;
+  }
+
+  if(options.hasOwnProperty("basePath")){
+    shopify._setBasePath(options.basePath);
+  }
 };
 
 /*
@@ -139,10 +165,12 @@ shopify.upload = function(filepath, file, host, base, themeid) {
 
 
 // plugin level function (dealing with files)
-function gulpShopifyUpload(apiKey, password, host, themeid) {
+function gulpShopifyUpload(apiKey, password, host, themeid, options) {
 
   // Set up the API
+  shopify._setOptions(options);
   shopifyAPI = shopify._getApi(apiKey, password, host);
+
   console.log('Ready to upload too ' + host);
 
   if(typeof apiKey === 'undefined'){


### PR DESCRIPTION
Hi Mike,

Please consider this PR, in which I re-enable the ability to change the base theme directory when uploading files. According to #1 the ability was removed, but I believe the added flexibility in the plugin will be a boon to users; certainly, I found I needed that ability, as did @NemoAlex (who raised the issue).

In the PR, I have added an additional, optional argument to the plugin. Now, one can call it from gulp as such:

``` js
var options = {
    "basePath": "some/other-dir/"
};

// With a theme id
gulpShopify('API KEY', 'PASSWORD', 'MYSITE.myshopify.com', 'THEME ID', options)

// Without a theme id
gulpShopify('API KEY', 'PASSWORD', 'MYSITE.myshopify.com',  null, options)
```

As it stands, the only option available is `basePath`, but by adding a simple options hash the plugin gains an easy way to add more flexibility in the future.

I will shortly add documentation updates to this PR.

Regards,
Andy Hunt
