### PR TITLE
Add support of callback function on file uploaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,13 +149,13 @@ shopify.upload = function(filepath, file, host, base, themeid) {
 
     function onUpdate(err, resp) {
         if (err && err.type === 'ShopifyInvalidRequestError') {
-            console.log('Error invalid upload request! ' + filepath + ' not uploaded to ' + host);
+            gutil.log(gutil.colors.red('Error invalid upload request! ' + filepath + ' not uploaded to ' + host));
         } else if (!err) {
             var filename = filepath.replace(/^.*[\\\/]/, '');
             gutil.log(gutil.colors.green('Upload Complete: ' + filename));
             shopify.oFileUploaded();
         } else {
-          console.log('Error undefined! ' + err.type);
+          gutil.log(gutil.colors.red('Error undefined! ' + err.type));
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -107,6 +107,8 @@ shopify._setOptions = function(options) {
   if(options.hasOwnProperty("basePath")){
     shopify._setBasePath(options.basePath);
   }
+
+  shopify.oFileUploaded = (options.hasOwnProperty("oFileUploaded") && options.oFileUploaded) || (function () {return undefined; })
 };
 
 /*
@@ -150,7 +152,8 @@ shopify.upload = function(filepath, file, host, base, themeid) {
             console.log('Error invalid upload request! ' + filepath + ' not uploaded to ' + host);
         } else if (!err) {
             var filename = filepath.replace(/^.*[\\\/]/, '');
-            console.log('Upload Complete: ' + filename);
+            gutil.log(gutil.colors.green('Upload Complete: ' + filename));
+            shopify.oFileUploaded();
         } else {
           console.log('Error undefined! ' + err.type);
         }
@@ -171,7 +174,7 @@ function gulpShopifyUpload(apiKey, password, host, themeid, options) {
   shopify._setOptions(options);
   shopifyAPI = shopify._getApi(apiKey, password, host);
 
-  console.log('Ready to upload too ' + host);
+  gutil.log('Ready to upload to ' + gutil.colors.magenta(host));
 
   if(typeof apiKey === 'undefined'){
     throw new PluginError(PLUGIN_NAME, 'Error, API Key for shopify does not exist!');


### PR DESCRIPTION
## Description

This PR contains minor improvements in order to:
- [x] Add support to set a callback function that is going to be trigger on file uploaded.
- [x] Add "prettier" colours on console messages related to upload files.

The main idea in the end is to be able to run some tasks after a file is uploaded.
## Screenshots

![shopperr-theme_ _gulp_shopifywatch_ _node_ _solarized_dark_ansi_ _158x42_and_slack](https://cloud.githubusercontent.com/assets/1425162/8707769/9f2be320-2b01-11e5-90ea-d6302f57fdca.jpg)

> _I have tried to follow the format of coding, if is there anything wrong please let me know and I will update it._
