### PR TITLE
Incorporates Shopify's API Leaky bucket algorithm for upload of files

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,11 @@
+{
+  "indent_size": 2,
+  "indent_char": " ",
+  "other": " ",
+  "indent_level": 0,
+  "indent_with_tabs": false,
+  "preserve_newlines": true,
+  "max_preserve_newlines": 2,
+  "jslint_happy": true,
+  "indent_handlebars": true
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,19 @@
+{
+    "browser": true,
+    "node": true,
+    "esnext": true,
+    "bitwise": true,
+    "camelcase": true,
+    "curly": true,
+    "eqeqeq": true,
+    "immed": true,
+    "indent": 2,
+    "latedef": true,
+    "newcap": true,
+    "noarg": true,
+    "quotmark": "single",
+    "undef": true,
+    "unused": true,
+    "strict": true,
+    "jquery": true
+}

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ gulp-shopify-upload
 ## Introduction
 
 **gulp-shopify-upload** is a [Gulpjs](https://github.com/gulpjs/gulp) plugin used to watch and upload theme files to Shopify.
-By using this plugin you can watch all of the different folders in a Shopify theme and have them automatically sync to your Shopify store on save. This is more lightweight than using Shopifys inline theme editor or desktop theme editor, and works on Windows, Mac and Linux.
+By using this plugin you can watch and deploy all of the different folders in a Shopify theme and have them automatically deploy to your Shopify store. This is more lightweight than using Shopifys inline theme editor or desktop theme editor, and works on all platforms that support Node (Windows, Mac and Linux).
 
 This is a port of a similar plugin using Grunt called [grunt-shopify](https://github.com/wilr/grunt-shopify), thank you to the author for making a great plugin for Shopify.
+
 ## Features
 
-- Uploads any file changes to Shopify on save in the folders:  `assets, layout, config, snippets, templates, locales`
-- Automatically uploads changes to the current working theme in shopify unless a themeid is specified
-- Lightweight and fast, changes are uploaded instantly
-
+- Uploads any file changes to Shopify in the folders:  `assets, layout, config, snippets, templates, locales`.
+- Automatically uploads changes to the current working theme in Shopify unless a themeid is specified.
+- Supports incremental file changes as well as a full site deploy for continuous integration.
+- Lightweight and fast, changes are uploaded instantly.
 
 ## Basic Usage
 
@@ -39,13 +40,13 @@ var watch = require('gulp-watch');
 var gulpShopify = require('gulp-shopify-upload');
 
 gulp.task('shopifywatch', function() {
-	return watch('./+(assets|layout|config|snippets|templates|locales)/**')
-	.pipe(gulpShopify('API KEY', 'PASSWORD', 'MYSITE.myshopify.com', 'THEME ID'));
+  return watch('./+(assets|layout|config|snippets|templates|locales)/**')
+    .pipe(gulpShopify('API KEY', 'PASSWORD', 'MYSITE.myshopify.com', 'THEME ID'));
 });
 
 // Default gulp action when gulp is run
 gulp.task('default', [
-        'shopifywatch'
+  'shopifywatch'
 ]);
 ```
 4. The basic function call looks like
@@ -56,16 +57,17 @@ gulpShopify('API KEY', 'PASSWORD', 'MYSITE.myshopify.com', 'THEME ID')
 	- `PASSWORD` is the Password generated when creating a private app in Shopify
 	- `MYSITE.myshopify.com` is the URL of your shop
 	- `THEME ID` is the ID of your theme and is **OPTIONAL**, if not passed in, the current working theme will be used
-4. Run `npm install gulp`, `npm install gulp-watch` and `npm install gulp-shopify-upload`
+4. Run `npm install gulp gulp-watch gulp-shopify-upload`
 5. Run `gulp` and edit one of your theme files, it should automatically be uploaded to Shopify
 
 ## Advanced Usage
+**Customize Your Base Deployment Path**
 If your project structure is different (perhaps you use Gulpjs to compile your theme to another directory), you can change the directory from which the plugin picks up files.
 To do so, simply provide an additional options hash to function call, with a `basePath` property.
 
 ```
 var options = {
-	"basePath": "some/other-directory/"
+  "basePath": "some/other-directory/"
 };
 
 // With a theme id
@@ -73,6 +75,16 @@ gulpShopify('API KEY', 'PASSWORD', 'MYSITE.myshopify.com', 'THEME ID', options)
 
 // Without a theme id
 gulpShopify('API KEY', 'PASSWORD', 'MYSITE.myshopify.com', null, options)
+```
+
+**Deploy the Entire Site**
+You can also deploy the entire site for use with continuous integration.
+```
+gulp.task('deploy', ['build'], function() {
+  return gulp.src('./+(assets|layout|config|snippets|templates|locales)/**')
+    .pipe(gulpShopify('API KEY', 'PASSWORD', 'MYSITE.myshopify.com', 'THEME ID'));
+;
+});
 ```
 
 *Created by [Able Sense Media](http://ablesense.com) - 2015*

--- a/index.js
+++ b/index.js
@@ -120,45 +120,33 @@ shopify._setOptions = function (options) {
  * @param {string} filepath
  * @param {Function} done
  */
-shopify.upload = function(filepath, file, host, base, themeid) {
+shopify.upload = function (filepath, file, host, base, themeid) {
 
-    var api = shopifyAPI,
-        themeId = themeid,
-        key = shopify._makeAssetKey(filepath, base),
-        isBinary = isBinaryFile(filepath),
-        props = {
-            asset: {
-                key: key
-            }
-        },
-        contents;
+  var api = shopifyAPI,
+    themeId = themeid,
+    key = shopify._makeAssetKey(filepath, base),
+    isBinary = isBinaryFile(filepath),
+    props = {
+      asset: {
+        key: key
+      }
+    },
+    contents;
 
-    contents = file.contents;
+  contents = file.contents;
 
-    if (isBinary) {
-        props.asset.attachment = contents.toString('base64');
-    } else {
-        props.asset.value = contents.toString();
-    }
+  if (isBinary) {
+    props.asset.attachment = contents.toString('base64');
+  } else {
+    props.asset.value = contents.toString();
+  }
 
-    function onUpdate(err, resp) {
-        if (err && err.type === 'ShopifyInvalidRequestError') {
-            gutil.log(gutil.colors.red('Error invalid upload request! ' + filepath + ' not uploaded to ' + host));
-        } else if (!err) {
-            var filename = filepath.replace(/^.*[\\\/]/, '');
-            gutil.log(gutil.colors.green('Upload Complete: ' + filename));
-        } else {
-          gutil.log(gutil.colors.red('Error undefined! ' + err.type));
-        }
-    }
-
-  function onUpdate(err) {
+  function onUpdate(err, resp) {
     if (err && err.type === 'ShopifyInvalidRequestError') {
       gutil.log(gutil.colors.red('Error invalid upload request! ' + filepath + ' not uploaded to ' + host));
     } else if (!err) {
       var filename = filepath.replace(/^.*[\\\/]/, '');
       gutil.log(gutil.colors.green('Upload Complete: ' + filename));
-      shopify.oFileUploaded();
     } else {
       gutil.log(gutil.colors.red('Error undefined! ' + err.type));
     }

--- a/index.js
+++ b/index.js
@@ -1,69 +1,65 @@
-var through = require('through2');
-var gutil = require('gulp-util');
-var path = require('path');
-var async = require('async');
-var isBinaryFile = require('isbinaryfile');
-var ShopifyApi = require('shopify-api');
-var PluginError = gutil.PluginError;
+'use strict';
+var through = require('through2'),
+  gutil = require('gulp-util'),
+  path = require('path'),
+  isBinaryFile = require('isbinaryfile'),
+  ShopifyApi = require('shopify-api'),
+  PluginError = gutil.PluginError,
+  shopify = {},
+  shopifyAPI,
+  PLUGIN_NAME = 'gulp-shopify-upload';
 
 // Set up shopify API information
-var shopify = {};
 shopify._api = false;
 shopify._basePath = false;
-
-// Store the connection here
-var shopifyAPI;
-
-// consts
-const PLUGIN_NAME = 'gulp-shopify-upload';
 
 /*
  * Get the Shopify API instance.
  *
  * @return {ShopifyApi}
  */
-shopify._getApi = function(apiKey, password, host) {
+shopify._getApi = function (apiKey, password, host) {
   if (!shopify._api) {
-      var opts = {
-          auth: apiKey + ':' + password,
-          host: host,
-          port: '443',
-          timeout: 120000
-      };
+    var opts = {
+      auth: apiKey + ':' + password,
+      host: host,
+      port: '443',
+      timeout: 120000
+    };
 
-      shopify._api = new ShopifyApi(opts);
+    shopify._api = new ShopifyApi(opts);
   }
 
   return shopify._api;
 };
 
 /*
-* Convert a file path on the local file system to an asset path in shopify
-* as you may run grunt at a higher directory locally.
-*
-* The original path to a file may be something like shop/assets/site.css
-* whereas we require assets/site.css in the API. To customize the base
-* set shopify.options.base config option.
-*
-* @param {string}
-* @return {string}
-*/
-shopify._makeAssetKey = function(filepath, base) {
+ * Convert a file path on the local file system to an asset path in shopify
+ * as you may run gulp at a higher directory locally.
+ *
+ * The original path to a file may be something like shop/assets/site.css
+ * whereas we require assets/site.css in the API. To customize the base
+ * set shopify.options.base config option.
+ *
+ * @param {string}
+ * @return {string}
+ */
+shopify._makeAssetKey = function (filepath, base) {
   filepath = shopify._makePathRelative(filepath, base);
 
   return encodeURI(filepath);
 };
 
 /*
-* Get the base path.
-*
-* @return {string}
-*/
-shopify._getBasePath = function(filebase) {
+ * Get the base path.
+ *
+ * @return {string}
+ */
+shopify._getBasePath = function (filebase) {
   if (!shopify._basePath) {
-      var base = filebase;
+    var base = filebase;
 
-      shopify._basePath = (base.length > 0) ? path.resolve(base) : process.cwd();
+    shopify._basePath = (base.length > 0) ? path.resolve(base) : process.cwd();
   }
 
   return shopify._basePath;
@@ -75,17 +71,17 @@ shopify._getBasePath = function(filebase) {
  * @param {string} basePath
  * @return {void}
  */
-shopify._setBasePath = function(basePath) {
+shopify._setBasePath = function (basePath) {
   shopify._basePath = basePath;
 };
 
 /**
-* Make a path relative to base path.
-*
-* @param {string} filepath
-* @return {string}
-*/
-shopify._makePathRelative = function(filepath, base) {
+ * Make a path relative to base path.
+ *
+ * @param {string} filepath
+ * @return {string}
+ */
+shopify._makePathRelative = function (filepath, base) {
   var basePath = shopify._getBasePath(base);
 
   filepath = path.relative(basePath, filepath);
@@ -99,76 +95,110 @@ shopify._makePathRelative = function(filepath, base) {
  * @param {object} options
  * @return {void}
  */
-shopify._setOptions = function(options) {
-  if(!options){
+shopify._setOptions = function (options) {
+  if (!options) {
     return;
   }
 
-  if(options.hasOwnProperty("basePath")){
+  if (options.hasOwnProperty('basePath')) {
     shopify._setBasePath(options.basePath);
   }
 
-  shopify.oFileUploaded = (options.hasOwnProperty("oFileUploaded") && options.oFileUploaded) || (function () {return undefined; })
+  shopify.oFileUploaded = (options.hasOwnProperty('oFileUploaded') && options.oFileUploaded) || function () {
+    return undefined;
+  };
+};
+
+//
+
+/*
+ * Process deployment queue for new files added via the stream.
+ * The queue is processed based on Shopify's leaky bucket algorithm that allows
+ * for infrequent bursts calls with a bucket size of 40. This regenerates overtime,
+ * but offers an unlimited leak rate of 2 calls per second. Use this variable to
+ * keep track of api call rate to calculate deployment.
+ * https://docs.shopify.com/api/introduction/api-call-limit
+ *
+ * @param {fileQueue} array - list of files to deploy to Shopify
+ * @param {host} string - hostname provided from gulp file
+ * @param {themeid} string - unique id upload to the Shopify theme
+ */
+shopify.deploy = function (fileQueue, host, themeid) {
+  var apiBurstBucketSize = 40,
+    i = 0;
+  for (; i < fileQueue.length; i++) {
+    // deploy immediately if within the burst bucket size, otherwise queue
+    if (i <= apiBurstBucketSize) {
+      shopify.upload(fileQueue[i].path, fileQueue[i], host, '', themeid);
+    } else {
+      // Delay deployment based on position in the array to deploy 2 files per second
+      // after hitting the initial burst bucket limit size
+      setTimeout(shopify.upload.bind(null, fileQueue[i].path, fileQueue[i], host, '', themeid), ((i - apiBurstBucketSize) / 2) * 1000);
+    }
+  }
 };
 
 /*
  * Upload a given file path to Shopify
  *
  * Assets need to be in a suitable directory.
- *      - Liquid templates => "templates/"
- *      - Liquid layouts => "layout/"
- *      - Liquid snippets => "snippets/"
- *      - Theme settings => "config/"
- *      - General assets => "assets/"
- *      - Language files => "locales/"
+ *      - Liquid templates => 'templates/'
+ *      - Liquid layouts => 'layout/'
+ *      - Liquid snippets => 'snippets/'
+ *      - Theme settings => 'config/'
+ *      - General assets => 'assets/'
+ *      - Language files => 'locales/'
  *
  * Some requests may fail if those folders are ignored
  * @param {string} filepath
  * @param {Function} done
  */
-shopify.upload = function(filepath, file, host, base, themeid) {
+shopify.upload = function (filepath, file, host, base, themeid) {
 
-    var api = shopifyAPI,
-        themeId = themeid,
-        key = shopify._makeAssetKey(filepath, base),
-        isBinary = isBinaryFile(filepath),
-        props = {
-            asset: {
-                key: key
-            }
-        },
-        contents;
+  var api = shopifyAPI,
+    themeId = themeid,
+    key = shopify._makeAssetKey(filepath, base),
+    isBinary = isBinaryFile(filepath),
+    props = {
+      asset: {
+        key: key
+      }
+    },
+    contents;
 
-    contents = file.contents;
+  contents = file.contents;
 
-    if (isBinary) {
-        props.asset.attachment = contents.toString('base64');
+  if (isBinary) {
+    props.asset.attachment = contents.toString('base64');
+  } else {
+    props.asset.value = contents.toString();
+  }
+
+  function onUpdate(err) {
+    if (err && err.type === 'ShopifyInvalidRequestError') {
+      gutil.log(gutil.colors.red('Error invalid upload request! ' + filepath + ' not uploaded to ' + host));
+    } else if (!err) {
+      var filename = filepath.replace(/^.*[\\\/]/, '');
+      gutil.log(gutil.colors.green('Upload Complete: ' + filename));
+      shopify.oFileUploaded();
     } else {
-        props.asset.value = contents.toString();
+      gutil.log(gutil.colors.red('Error undefined! ' + err.type));
     }
+  }
 
-    function onUpdate(err, resp) {
-        if (err && err.type === 'ShopifyInvalidRequestError') {
-            gutil.log(gutil.colors.red('Error invalid upload request! ' + filepath + ' not uploaded to ' + host));
-        } else if (!err) {
-            var filename = filepath.replace(/^.*[\\\/]/, '');
-            gutil.log(gutil.colors.green('Upload Complete: ' + filename));
-            shopify.oFileUploaded();
-        } else {
-          gutil.log(gutil.colors.red('Error undefined! ' + err.type));
-        }
-    }
-
-    if (themeId) {
-      api.asset.update(themeId, props, onUpdate);
-    } else {
-      api.assetLegacy.update(props, onUpdate);
-    }
+  if (themeId) {
+    api.asset.update(themeId, props, onUpdate);
+  } else {
+    api.assetLegacy.update(props, onUpdate);
+  }
 };
-
 
 // plugin level function (dealing with files)
 function gulpShopifyUpload(apiKey, password, host, themeid, options) {
+
+  // queue files provided in the stream for deployment
+  var fileQueue = [],
+    stream;
 
   // Set up the API
   shopify._setOptions(options);
@@ -176,37 +206,40 @@ function gulpShopifyUpload(apiKey, password, host, themeid, options) {
 
   gutil.log('Ready to upload to ' + gutil.colors.magenta(host));
 
-  if(typeof apiKey === 'undefined'){
+  if (typeof apiKey === 'undefined') {
     throw new PluginError(PLUGIN_NAME, 'Error, API Key for shopify does not exist!');
-  };
-  if(typeof password === 'undefined'){
+  }
+  if (typeof password === 'undefined') {
     throw new PluginError(PLUGIN_NAME, 'Error, password for shopify does not exist!');
-  };
-  if(typeof host === 'undefined'){
+  }
+  if (typeof host === 'undefined') {
     throw new PluginError(PLUGIN_NAME, 'Error, host for shopify does not exist!');
-  };
+  }
 
   // creating a stream through which each file will pass
-  var stream = through.obj(function(file, enc, cb) {
-    if (file.isStream()) {
-      this.emit('error', new PluginError(PLUGIN_NAME, 'Streams are not supported!'));
-      return cb();
-    }
+  stream = through.obj(function (file, enc, cb) {
+      if (file.isStream()) {
+        this.emit('error', new PluginError(PLUGIN_NAME, 'Streams are not supported!'));
+        return cb();
+      }
 
-    if (file.isBuffer()) {
-      shopify.upload(file.path, file, host, '', themeid);
-    }
+      if (file.isBuffer()) {
+        fileQueue.push(file);
+      }
 
-    // make sure the file goes through the next gulp plugin
-    this.push(file);
+      // make sure the file goes through the next gulp plugin
+      this.push(file);
 
-    // tell the stream engine that we are done with this file
-    cb();
-  });
+      // tell the stream engine that we are done with this file
+      cb();
+    })
+    .on('end', function () {
+      shopify.deploy(fileQueue, host, themeid);
+    });
 
   // returning the file stream
   return stream;
-};
+}
 
 // exporting the plugin main function
 module.exports = gulpShopifyUpload;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
       "name": "Mike Northorp",
       "email": "mike.northorp@gmail.com",
       "url": "https://github.com/mikenorthorp"
+    },
+    {
+      "name": "Roy Martin",
+      "email": "roy@roy-martin.com",
+      "url": "https://github.com/rmartin"
     }
   ],
   "main": "index.js",
@@ -30,7 +35,6 @@
     "url": "git://github.com/mikenorthorp/gulp-shopify-upload.git"
   },
   "dependencies": {
-    "async": "0.2.9",
     "isbinaryfile": "2.0.0",
     "path": "0.11.14",
     "shopify-api": "0.2.2",


### PR DESCRIPTION
hey @mikenorthorp ,

Please find my attached implementation of this solution to resolve https://github.com/mikenorthorp/gulp-shopify-upload/issues/10 . The takes advantage of the burst bucket size and automatically uploads the first 40 files at once. Subsequent files are queued to deploy roughly 2 files per second for the duration of the deploy. While this could technically be further optimized to watch the header response for a 'refill' of the burst speed, this seems sufficient to resolve any deployment errors due to the rate limit. 

In addition to this solution I have also updated README, package and added a few editor configs to allow for consistency for the spacing and validation on the project. Let me know if you have any concerns with those additions / updates.

If you have a chance, give the overall approach a look and let me know if you'd like to see anything adjusted prior to merging in.

Cheers,
Roy
