### PR TITLE
remove shopify.oFileUploaded option

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,8 +107,6 @@ shopify._setOptions = function(options) {
   if(options.hasOwnProperty("basePath")){
     shopify._setBasePath(options.basePath);
   }
-
-  shopify.oFileUploaded = (options.hasOwnProperty("oFileUploaded") && options.oFileUploaded) || (function () {return undefined; })
 };
 
 /*
@@ -153,7 +151,6 @@ shopify.upload = function(filepath, file, host, base, themeid) {
         } else if (!err) {
             var filename = filepath.replace(/^.*[\\\/]/, '');
             gutil.log(gutil.colors.green('Upload Complete: ' + filename));
-            shopify.oFileUploaded();
         } else {
           gutil.log(gutil.colors.red('Error undefined! ' + err.type));
         }


### PR DESCRIPTION
This function is causing errors on new installs: https://github.com/mikenorthorp/gulp-shopify-upload/issues/13

This function does nothing at best, and causes an error at worst. 

After a successful upload, this line is called: `shopify.oFileUploaded()`. Taking a look at the options, we get this: `shopify.oFileUploaded = (options.hasOwnProperty("oFileUploaded") && options.oFileUploaded) || (function () {return undefined; })`. The first conditional sets `oFileUploaded` to `true` if the property is set and equates to `true`. This is already a problem, because it would break the above line of code that tries to call `oFileUploaded` as a function. However, this never happens, and as a result, `shopify.oFileUploaded` always returns a function that does nothing.

I really don't understand why this is here at all, unless I'm missing something?
