### PR TITLE
Removed ability to accidentally overwrite production

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ shopify.upload = function (filepath, file, host, base, themeid) {
     }
   }
 
-  if (themeId == "__production__") {
+  if (themeId === "__production__") {
     api.assetLegacy.update(props, onUpdate);
   } else if (themeId) {
     api.asset.update(themeId, props, onUpdate);

--- a/index.js
+++ b/index.js
@@ -152,10 +152,12 @@ shopify.upload = function (filepath, file, host, base, themeid) {
     }
   }
 
-  if (themeId) {
+  if (themeId == "__production__") {
+    api.assetLegacy.update(props, onUpdate);
+  } else if (themeId) {
     api.asset.update(themeId, props, onUpdate);
   } else {
-    api.assetLegacy.update(props, onUpdate);
+    gutil.log(gutil.colors.red('Error theme ID not set! Please set your theme ID or use "__production__" to default to the current working theme'));
   }
 };
 


### PR DESCRIPTION
closes #28 

This is a breaking change that would force users who have previously relied on overriding production without a Theme ID to enter "__production__" as their Theme ID. However, it is descriptive in that it reports this in the console.

Hopefully you will consider this pull request, so that nobody else has the kind of day I have had!
